### PR TITLE
Add boto3 version specifier to setup so at least 1.4.0 is installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     long_description="\n".join(__doc__.split("\n")[2:]),
     install_requires=install_requires,
     extras_require={
-        'cloud': ['boto3'],
+        'cloud': ['boto3>=1.4.0'],
         'completion': ['argcomplete'],
     },
     platforms=['Linux', 'Mac OS X'],


### PR DESCRIPTION
Add boto3 version specifier
- At least boto3>=1.4.0 is required for upload_fileobj